### PR TITLE
[Kyungwon] API 리스트 및 기능 관리를 위한 drf-yasg 도입, API 동작 확인을 위한 test API 생성 테스트

### DIFF
--- a/server/daangn/daangn/settings.py
+++ b/server/daangn/daangn/settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'corsheaders',
     'member',
+    'drf_yasg',
 ]
 
 MIDDLEWARE = [

--- a/server/daangn/daangn/urls.py
+++ b/server/daangn/daangn/urls.py
@@ -15,8 +15,24 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
+from rest_framework import permissions
+
+schema_view = get_schema_view(
+   openapi.Info(
+      title="DAANGN_API_DOCS",
+      default_version='v1',
+      description="Test description"
+   ),
+   public=True,
+   permission_classes=(permissions.AllowAny,),
+)
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('member/', include('member.urls')),
+    # path('swagger<str:format>', schema_view.without_ui(cache_timeout=0), name='schema-json'),
+    path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+    path('docs/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
 ]

--- a/server/daangn/member/urls.py
+++ b/server/daangn/member/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     path('product/', views.product_list, name='prduct_list'),
     path('product/<pk>', views.product_detail, name='prduct_detail'),
     path('overlap/', views.member_overlap, name='overlap'),
+    path('test/', views.test, name='test'),
     path('<pk>/', views.member_detail, name='member_detail'),
 ]
 

--- a/server/daangn/member/views.py
+++ b/server/daangn/member/views.py
@@ -158,4 +158,9 @@ def product_search(request):
     return Response(serializer.data)
     # return HttpResponse(product)
 
-    
+@api_view(['GET'])
+def test(request):
+    """
+    테스트용 api
+    """
+    return Response(status=status.HTTP_200_OK)


### PR DESCRIPTION
# 작업내용
1. API 리스트 및 기능 관리를 위한 drf-yasg 도입
2. API 동작 확인을 위한 test API 생성 테스트

# 과정
## DRF-YASG 도입
- 참고: https://github.com/axnsan12/drf-yasg
## 설치방법
1. 필요 라이브러리 설치
    ```
    pip install -U drf-yasg
2. 소스에 아래 내용 추가
    - settings.py
        ``` python
        INSTALLED_APPS = [
             ...,
            'drf_yasg',
        ]
    - urls.py
        ``` python
        from drf_yasg.views import get_schema_view
        from drf_yasg import openapi
        from rest_framework import permissions
        ...
        schema_view = get_schema_view(
           openapi.Info(
              title="DAANGN_API_DOCS",
              default_version='v1',
              description="Test description"
           ),
           public=True,
           permission_classes=(permissions.AllowAny,),
        )

        urlpatterns = [
            ...
            path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
            path('docs/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
        ]

## 사용방법
- http://localhost:8000/swagger/
- http://localhost:8000/docs/

# 참고사항 (API 동작 확인을 위한 test api 추가 시 확인했던 특이사항)
## urlpattern 내에서의 위치의 중요성
### 정상동작
[http://localhost:8000/member/test/](http://localhost:8000/member/test/)
![image](https://user-images.githubusercontent.com/29250689/81793038-cba29a00-9543-11ea-9f5c-276007892112.png)

```python
from django.urls import path
from member import views
from rest_framework.urlpatterns import format_suffix_patterns

urlpatterns = [
    path('', views.member_list, name='member_list'),
    path('login/', views.member_login, name='login'),
    path('product/search/', views.product_search, name='prduct_search'),
    path('product/', views.product_list, name='prduct_list'),
    path('product/<pk>', views.product_detail, name='prduct_detail'),
    path('overlap/', views.member_overlap, name='overlap'),
    path('test/', views.test, name='test'),
    path('<pk>/', views.member_detail, name='member_detail'),
]

urlpatterns = format_suffix_patterns(urlpatterns)
```
### 비정상동작
![image](https://user-images.githubusercontent.com/29250689/81793076-d52c0200-9543-11ea-8a77-828eb7062c9e.png)

```python
from django.urls import path
from member import views
from rest_framework.urlpatterns import format_suffix_patterns

urlpatterns = [
    path('', views.member_list, name='member_list'),
    path('login/', views.member_login, name='login'),
    path('product/search/', views.product_search, name='prduct_search'),
    path('product/', views.product_list, name='prduct_list'),
    path('product/<pk>', views.product_detail, name='prduct_detail'),
    path('overlap/', views.member_overlap, name='overlap'),
    path('<pk>/', views.member_detail, name='member_detail'),
    path('test/', views.test, name='test'),
]

urlpatterns = format_suffix_patterns(urlpatterns)
```