### PR TITLE
[KyungWon] Login 시에만 last_date 업데이트하도록 변경 / 회원정보 수정 시에는 udate만 업데이트하도록 변경

### DIFF
--- a/server/daangn/member/models.py
+++ b/server/daangn/member/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.utils import timezone
 now = timezone.now()
+
 class Company(models.Model):
     id_company = models.AutoField(primary_key=True)
     id_member = models.ForeignKey('Member', models.DO_NOTHING, db_column='id_member')
@@ -40,6 +41,7 @@ class Manner(models.Model):
 
 
 class Member(models.Model):
+    
     id_member = models.AutoField(primary_key=True)
     name = models.CharField(max_length=30)
     nick_name = models.CharField(max_length=30)
@@ -49,11 +51,15 @@ class Member(models.Model):
     birth = models.DateField()
     email = models.CharField(max_length=30)
     gender = models.CharField(max_length=6)
-    add = models.CharField(max_length=200)
+    addr = models.CharField(max_length=200)
     cdate = models.DateTimeField(auto_now_add=True)
-    udate = models.DateTimeField(auto_now=True)
-    last_date = models.DateTimeField(auto_now=True)
+    udate = models.DateTimeField(auto_now=False)
+    last_date = models.DateTimeField(auto_now=False)
 
+    # def login(i):
+    #     LOGIN_YN = i
+    #     print(LOGIN_YN)
+    #     print(Member.last_date)
     class Meta:
         managed = False
         db_table = 'member'

--- a/server/daangn/member/models.py
+++ b/server/daangn/member/models.py
@@ -41,7 +41,6 @@ class Manner(models.Model):
 
 
 class Member(models.Model):
-    
     id_member = models.AutoField(primary_key=True)
     name = models.CharField(max_length=30)
     nick_name = models.CharField(max_length=30)
@@ -56,10 +55,6 @@ class Member(models.Model):
     udate = models.DateTimeField(auto_now=False)
     last_date = models.DateTimeField(auto_now=False)
 
-    # def login(i):
-    #     LOGIN_YN = i
-    #     print(LOGIN_YN)
-    #     print(Member.last_date)
     class Meta:
         managed = False
         db_table = 'member'

--- a/server/daangn/member/serializers.py
+++ b/server/daangn/member/serializers.py
@@ -1,11 +1,13 @@
 from django.forms import widgets
 from rest_framework import serializers
 from member.models import *
+# from member.serializers import *
 
 class MemberSerializer(serializers.ModelSerializer):
     class Meta:
         model = Member
-        fields = ('pk', 'name', 'nick_name', 'user_id', 'user_pw', 'tel', 'birth', 'email', 'gender', 'add')
+        fields = ('pk', 'name', 'nick_name', 'user_id', 'user_pw', 'tel', 'birth', 'email', 'gender')
+        read_only_fields = ('account_name')
         #fields = ('pk', 'name', 'nick_name', 'user_id', 'user_pw', 'tel', 'birth', 'email', 'gender', 'addr')
 
 class MemberReviseSerializer(serializers.ModelSerializer):
@@ -28,10 +30,10 @@ class ProductSerializer(serializers.ModelSerializer):
         fields = ('pk', 'id_member', 'name', 'price', 'info', 'category', 'img')
 
 class LoginSerializer(serializers.ModelSerializer):
+    last_date = serializers.DateTimeField(default=timezone.now)
     class Meta:
         model = Member
-        fields = ('pk', 'user_id', 'name','nick_name', 'tel', 'add')
-        #fields = ('pk', 'user_id', 'name','nick_name', 'tel', 'addr')
+        fields = ('user_id', 'user_pw', 'last_date')
 
 class CompanySerializer(serializers.ModelSerializer):
     class Meta:

--- a/server/daangn/member/serializers.py
+++ b/server/daangn/member/serializers.py
@@ -10,16 +10,18 @@ class MemberSerializer(serializers.ModelSerializer):
         fields = ('pk', 'name', 'nick_name', 'user_id', 'user_pw', 'tel', 'birth', 'email', 'gender', 'addr')
 
 class MemberReviseSerializer(serializers.ModelSerializer):
+    udate = serializers.DateTimeField(default=timezone.now)
     class Meta:
         model = Member
-        # fields = ('pk', 'nick_name', 'user_pw', 'tel', 'birth', 'email', 'add')
-        fields = ('pk', 'nick_name', 'user_pw', 'tel', 'birth', 'email', 'addr')
+        # 추후 주소 수정 시 addr 넣어야 함. 현재는 udate 수정 확인을 위해 빼 놓았음
+        fields = ('pk', 'nick_name', 'user_pw', 'tel', 'birth', 'email', 'udate')
 
 class MemberTouchSerializer(serializers.ModelSerializer):
+    udate = serializers.DateTimeField(default=timezone.now)
     class Meta:
         model = Member
         # fields = ('pk', 'nick_name', 'add')
-        fields = ('pk', 'nick_name', 'addr', 'user_img')
+        fields = ('pk', 'nick_name', 'addr', 'user_img', 'udate')
         
 class ProductSerializer(serializers.ModelSerializer):
     # id_member_id = serializers.IntegerField(source='id_member')

--- a/server/daangn/member/serializers.py
+++ b/server/daangn/member/serializers.py
@@ -6,21 +6,20 @@ from member.models import *
 class MemberSerializer(serializers.ModelSerializer):
     class Meta:
         model = Member
-        fields = ('pk', 'name', 'nick_name', 'user_id', 'user_pw', 'tel', 'birth', 'email', 'gender')
-        read_only_fields = ('account_name')
-        #fields = ('pk', 'name', 'nick_name', 'user_id', 'user_pw', 'tel', 'birth', 'email', 'gender', 'addr')
+        # fields = ('pk', 'name', 'nick_name', 'user_id', 'user_pw', 'tel', 'birth', 'email', 'gender')
+        fields = ('pk', 'name', 'nick_name', 'user_id', 'user_pw', 'tel', 'birth', 'email', 'gender', 'addr')
 
 class MemberReviseSerializer(serializers.ModelSerializer):
     class Meta:
         model = Member
-        fields = ('pk', 'nick_name', 'user_pw', 'tel', 'birth', 'email', 'add')
-        #fields = ('pk', 'nick_name', 'user_pw', 'tel', 'birth', 'email', 'addr')
+        # fields = ('pk', 'nick_name', 'user_pw', 'tel', 'birth', 'email', 'add')
+        fields = ('pk', 'nick_name', 'user_pw', 'tel', 'birth', 'email', 'addr')
 
 class MemberTouchSerializer(serializers.ModelSerializer):
     class Meta:
         model = Member
-        fields = ('pk', 'nick_name', 'add')
-        #fields = ('pk', 'nick_name', 'addr', 'user_img')
+        # fields = ('pk', 'nick_name', 'add')
+        fields = ('pk', 'nick_name', 'addr', 'user_img')
         
 class ProductSerializer(serializers.ModelSerializer):
     # id_member_id = serializers.IntegerField(source='id_member')

--- a/server/daangn/member/views.py
+++ b/server/daangn/member/views.py
@@ -22,6 +22,7 @@ def member_list(request):
         return Response(serializer.data)
 
     elif request.method == 'POST':
+        # 아이디에 대한 중복 확인 필요
         serializer = MemberSerializer(data=request.data)
         if serializer.is_valid():
             serializer.save()
@@ -159,7 +160,11 @@ def member_login(request):
     #     return Response(status=status.HTTP_200_OK)
 
     if request.method == 'POST':
-        serializer = LoginSerializer(member)
+        
+        # serializer = LoginSerializer(member)
+        serializer = LoginSerializer(member, data=request.data)
+        if serializer.is_valid():
+            serializer.save()
         return Response(serializer.data)
     
     else:


### PR DESCRIPTION
# 작업내용
1. Member model의 udate, last_date의 auto_now를 False로 수정
2. LoginSerializer에 last_date 필드 현재 시간으로 업데이트하도록 오버라이드
3. LoginSerializer 기반 save
4. /member/{pk} (회원정보 수정) 시 udate만 업데이트하도록 변경
5. /member/touch/{pk} (회원정보 간단 수정) 시 udate만 업데이트하도록 변경

# 참고
https://www.django-rest-framework.org/api-guide/serializers/#specifying-fields-explicitly