### PR TITLE
[Seonwoo]실거래 등록, 특정 제품의 실거래 조회, 판매자/구매자 리뷰 등록, 리뷰 조회 함수, 모델 오타 수정

### DIFF
--- a/server/daangn/member/models.py
+++ b/server/daangn/member/models.py
@@ -103,7 +103,7 @@ class Member(models.Model):
         db_table = 'member'
 
 
-    class Memberaddr(models.Model):
+class Memberaddr(models.Model):
     id_memberaddr = models.AutoField(primary_key=True)
     id_member = models.ForeignKey(Member, models.DO_NOTHING, db_column='id_member')
     addr = models.CharField(max_length=200)

--- a/server/daangn/member/models.py
+++ b/server/daangn/member/models.py
@@ -104,7 +104,7 @@ class Member(models.Model):
 
 
     class Memberaddr(models.Model):
-    id_amemberddr = models.AutoField(primary_key=True)
+    id_memberaddr = models.AutoField(primary_key=True)
     id_member = models.ForeignKey(Member, models.DO_NOTHING, db_column='id_member')
     addr = models.CharField(max_length=200)
 

--- a/server/daangn/member/serializers.py
+++ b/server/daangn/member/serializers.py
@@ -52,29 +52,48 @@ class WishlistSerializer(serializers.ModelSerializer):
 
 
 # realdeal api 
-class RealDealSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Wishlist
-        fields = ('pk', 'id_product', 'cdate')
-
 class MemberSellerSerializer(serializers.ModelSerializer):
     class Meta:
-        model = Wishlist
+        id_member = MemberSerializer(read_only= True)
+        model = MemberSeller
         fields = ('id_member', 'id_real_deal')
+
 
 class MemberShopperSerializer(serializers.ModelSerializer):
     class Meta:
-        model = Wishlist
+        model = MemberShopper
         fields = ('id_member', 'id_real_deal')
+
+        
+class RealDealSerializer(serializers.ModelSerializer):
+    seller = serializers.IntegerField(read_only=True)
+    shopper = serializers.IntegerField(read_only=True)
+    class Meta:
+        model = RealDeal
+        fields = ('pk', 'id_product','seller', 'shopper', 'cdate')
+
+
+class SellerRateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SellerRate
+        fields = ('id_review_seller', 'id_rate')
+
+
+class ShopperRateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ShopperRate
+        fields = ('id_review_shopper', 'id_rate')
+
 
 class SellerReviewSerializer(serializers.ModelSerializer):
     class Meta:
-        model = Wishlist
+        model = SellerReview
         fields = ('pk', 'id_real_deal', 'title', 'cdate')
+
 
 class ShopperReviewSerializer(serializers.ModelSerializer):
     class Meta:
-        model = Wishlist
+        model = ShopperReview
         fields = ('pk', 'id_real_deal', 'title', 'cdate')
 
 

--- a/server/daangn/member/urls.py
+++ b/server/daangn/member/urls.py
@@ -19,6 +19,10 @@ urlpatterns = [
     path('company/<pk>', views.company_detail, name='company_detail'),
     path('wishlist', views.wishlist_list, name='wishlist_list'),
     path('wishlist/<pk>', views.wishlist_detail, name='wishlist_detail'),
+    path('realdeal', views.realdeal_list, name='realdeal_list'),
+    path('realdeal/<pk>', views.realdeal_detail, name='realdeal_detail'),
+    path('sellerreview', views.seller_review, name='seller_review_list'),
+    path('shopperreview', views.shopper_review, name='shopper_review_list'),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)


### PR DESCRIPTION
## 작업내용 한줄 요약
실거래 등록, 특정 제품의 실거래 조회, 판매자/구매자 리뷰 등록, 리뷰 조회 함수, 모델 오타 수정
## 작업내용들 자세하게
urls
```
realdeal
realdeal/<pk>
sellerreview
shopperreview
```
```
- allow method : GET, POST
realdeal
모든 실거래를 조회하거나 새로운 실거래를 등록 할 수 있다.

- GET
모든 실거래 리스트를 받아온다. 
- POST
새로운 실거래를 등록한다
```
```
- allow method : GET
realdeal/<pk>
특정 제품의 실거래를 조회한다.

- GET
제품 pk를 통해 특정 제품의 실거래를 받아온다
```
```
- allow method : POST
sellerreview/<pk>
판매자가 리뷰를 작성하기 위한 api

- POST

```
```
- allow method : POST
shopperreview/<pk>
구매자가 리뷰를 작성하기 위한 api

- POST

```
```
- 리뷰를 조회할 함수
#특정 실거래의 구매자 리뷰
def shopper_review_list(id_real_deal) :
    shopperreview = ShopperReview.objects.filter(id_real_deal = id_real_deal)
    serializer = ShopperReviewSerializer(shopperreview, many=True)
    return serializer.data


#특정 실거래의 구매자 리뷰
def seller_review_list(id_real_deal) :
    sellerreview = ShopperReview.objects.filter(id_real_deal = id_real_deal)
    serializer = ShopperReviewSerializer(sellerreview, many=True)
    return serializer.data
```
```
- model.py 오타 수정
class Memberaddr(models.Model):
    id_memberaddr = models.AutoField(primary_key=True)
    id_member = models.ForeignKey(Member, models.DO_NOTHING, db_column='id_member')
    addr = models.CharField(max_length=200)
```

## 배운점