### PR TITLE
[KyungWon] 찜 등록 API + 멤버의 판매상품 조회 API 로직 수정

### DIFF
--- a/server/daangn/member/models.py
+++ b/server/daangn/member/models.py
@@ -214,8 +214,8 @@ class ShopperReview(models.Model):
 
 class Wishlist(models.Model):
     id_wishlist = models.AutoField(primary_key=True)
-    id_product = models.ForeignKey(Product, models.DO_NOTHING, db_column='id_product')
-    id_member = models.ForeignKey(Member, models.DO_NOTHING, db_column='id_member')
+    id_product = models.ForeignKey(Product, models.PROTECT, db_column='id_product')
+    id_member = models.ForeignKey(Member, models.PROTECT, db_column='id_member')
     cdate = models.DateTimeField(auto_now_add=True)
 
     class Meta:


### PR DESCRIPTION
# 작업 내용
1. 찜 등록 API (`POST /wishlist`) 로직 수정
    - 멤버 본인이 등록한 상품에 대해서는 찜리스트 추가 불가
    - 이미 찜리스트에 등록된 상품은 찜리스트 추가 불가
2. 특정 멤버의 판매상품 조회 (`GET /product/selling/<id_member>`) 로직 수정
    - Wishlist.objects.filter() 사용 시 DoesNotExist Exception 처리 무의미하므로 제거

# 배운 내용
- objects.get은 단건을 조회하기 위한 용도이고, 없을 경우 DoesNotExist에러를 발생시킨다.
- objects.filter는 여러 건의 객체를 조회하기 위한 용도이고, 없을 경우 빈 queryset을 리턴한다.
- 즉, filter를 할 때 DoesNotExist Exception을 체크하는 것은 의미가 없다.
@ddusi @DevLeeSeonwoo 위 내용 참고하셔서 혹시 지금까지 filter를 사용했는데 except를 DoesNotExist로 날린 경우에 대한 로직 수정 바랍니다.