### PR TITLE
[won-sang] MemberAddr API 생성/ 로직변경 ( 중복체크, 선택삭제 )

### DIFF
--- a/server/daangn/member/views.py
+++ b/server/daangn/member/views.py
@@ -102,7 +102,7 @@ def member_addr_create(request):
                     # return Response(serializer.data, status=status.HTTP_201_CREATED)
 
 
-        elif Memberaddr.objects.filter(id_member = id_member).count() >= 2 : 
+        elif Person.count() >= 2 : 
             content = {
             "message" : "허용된 주소의 갯수는 2개입니다.",
             "result" : {}
@@ -136,23 +136,22 @@ def member_addr(request, id_member):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     elif request.method == 'DELETE':
-        # q = request.data.dict()
-        # qaddr = q['addr']
-        # memberAddr_delete = Memberaddr.objects.filter(id_member = id_member).filter(addr = qaddr)
-        # memberAddr_delete.delete()
-        memberAddr.delete()
+        # 파라미터 get방식
+        # Addr = request.GET['addr']
+
+        # 제이슨 방식
+        data = request.body.decode('utf-8')
+        received_json_data = json.loads(data)
+        Addr = received_json_data['addr']
+        q = memberAddr.get(addr = Addr)
+        q.delete()
         content = {
-            "message" : "pk :" + pk + " 삭제 완료",
-            "result" : {}
+            "message" : "삭제 완료",
+            "result" : {"addr" : Addr}
                 }
-        '''
-        q = request.data.dict()
-        qid_product = q['id_product']
-        wishlist_delete = Wishlist.objects.filter(id_member = id_member).filter(id_product = qid_product)
-        wishlist_delete.delete()
-        '''
         return Response(content ,status=status.HTTP_204_NO_CONTENT)
 
+        
 @api_view(['PUT'])
 def member_touch(request, id_member):
     """

--- a/server/daangn/member/views.py
+++ b/server/daangn/member/views.py
@@ -21,7 +21,6 @@ def member_list(request):
     ---
     모든 유저의 정보를 보여주거나 새 유저 정보를 등록합니다.
     """
-    
     if request.method == 'GET':
         member = Member.objects.all()
         serializer = MemberSerializer(member, many=True)
@@ -110,7 +109,7 @@ def member_addr_create(request):
             return Response(content, status=status.HTTP_400_BAD_REQUEST)
 
 
-@api_view(['GET','PUT', 'DELETE'])
+@api_view(['GET', 'DELETE'])
 def member_addr(request, id_member):
     """
     멤버 주소 조회 수정, 삭제
@@ -128,13 +127,6 @@ def member_addr(request, id_member):
         serializer = memberAddrSerializer(memberAddr, many=True)
         return Response(serializer.data)
 
-    elif request.method == 'PUT':
-        serializer = memberAddrSerializer(memberAddr, data=request.data)
-        if serializer.is_valid():
-            serializer.save()
-            return Response(serializer.data)
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
     elif request.method == 'DELETE':
         # 파라미터 get방식
         # Addr = request.GET['addr']
@@ -151,7 +143,7 @@ def member_addr(request, id_member):
                 }
         return Response(content ,status=status.HTTP_204_NO_CONTENT)
 
-        
+
 @api_view(['PUT'])
 def member_touch(request, id_member):
     """

--- a/server/daangn/member/views.py
+++ b/server/daangn/member/views.py
@@ -115,7 +115,7 @@ def member_addr(request, id_member):
     멤버 주소 조회 수정, 삭제
     """
     try:
-        memberAddr = Memberaddr.objects.filter(id_member=id_member)
+        memberAddr = Memberaddr.objects.get(id_member=id_member)
     except Memberaddr.DoesNotExist:
         content = {
             "message" : "없는 사용자 입니다.",

--- a/server/daangn/member/views.py
+++ b/server/daangn/member/views.py
@@ -10,8 +10,6 @@ import json
 from django.http import JsonResponse
 from drf_yasg.utils import swagger_auto_schema
 
-now = timezone.now()
-
 # 'method' can be used to customize a single HTTP method of a view
 @swagger_auto_schema(method='get', responses={200:'OK'})
 # 'methods' can be used to apply the same modification to multiple methods
@@ -85,7 +83,7 @@ def member_addr_create(request):
                 serializer.save()
                 return Response(serializer.data, status=status.HTTP_201_CREATED)
 
-        elif Memberaddr.objects.filter(id_member = qid_member).count() >= 3 : 
+        elif Memberaddr.objects.filter(id_member = qid_member).count() >= 2 : 
             content = {
             "message" : "허용된 주소의 갯수는 2개입니다.",
             "result" : {}
@@ -93,7 +91,7 @@ def member_addr_create(request):
             return Response(content, status=status.HTTP_400_BAD_REQUEST)
 
 
-@api_view(['GET'])
+@api_view(['GET','PUT', 'DELETE'])
 def member_addr(request, id_member):
     """
     멤버 주소 조회 수정, 삭제
@@ -112,19 +110,19 @@ def member_addr(request, id_member):
         return Response(serializer.data)
 
     elif request.method == 'PUT':
-        serializer = MemberReviseSerializer(member, data=request.data)
+        serializer = memberAddrSerializer(memberAddr, data=request.data)
         if serializer.is_valid():
             serializer.save()
             return Response(serializer.data)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-    # elif request.method == 'DELETE':
-    #     member.delete()
-    #     content = {
-    #         "message" : "pk :" + pk + " 삭제 완료",
-    #         "result" : {}
-    #             }
-    #     return Response(content ,status=status.HTTP_204_NO_CONTENT)
+    elif request.method == 'DELETE':
+        memberAddr.delete()
+        content = {
+            "message" : "pk :" + pk + " 삭제 완료",
+            "result" : {}
+                }
+        return Response(content ,status=status.HTTP_204_NO_CONTENT)
 
 @api_view(['PUT'])
 def member_touch(request, id_member):

--- a/server/daangn/member/views.py
+++ b/server/daangn/member/views.py
@@ -81,25 +81,24 @@ def member_addr_create(request):
     #     member = Member.objects.get(user_id = user_id, user_pw = user_pw)
 
     if request.method == 'POST':
-        Data = json.loads(request.body)
-        id_member = Data['id_member']
-        addr = Data['addr']
-        if Memberaddr.objects.filter(id_member = id_member).count() < 2 :
-            data = request.body.decode('utf-8')
-            qaddr = json.loads(data)['addr']
-    
+        data = request.body.decode('utf-8')
+        received_json_data = json.loads(data)
+        id_member = received_json_data['id_member']
+        addr = received_json_data['addr']
+        Person = Memberaddr.objects.filter(id_member = id_member)
+        if Person.count() < 2 :
             try:
-                overlap = Memberaddr.objects.filter(id_member = id_member, addr = addr)
+                overlap = Person.get(addr = addr)
                 content = {
                 "message" : "중복된 주소가 있습니다.",
-                "result" : {overlap}
+                "result" : {"id_member = " + str(id_member) : addr}
                 }
             except Memberaddr.DoesNotExist:
                 serializer = memberAddrSerializer(data=request.data)
                 if serializer.is_valid():
                     serializer.save()
                     return Response(serializer.data, status=status.HTTP_201_CREATED)
-            return Response(overlap, status=status.HTTP_409_CONFLICT)
+            return Response(content, status=status.HTTP_409_CONFLICT)
                     # return Response(serializer.data, status=status.HTTP_201_CREATED)
 
 
@@ -137,10 +136,11 @@ def member_addr(request, id_member):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     elif request.method == 'DELETE':
-        q = request.data.dict()
-        qaddr = q['addr']
-        memberAddr_delete = Memberaddr.objects.filter(id_member = id_member).filter(addr = qaddr)
-        memberAddr_delete.delete()
+        # q = request.data.dict()
+        # qaddr = q['addr']
+        # memberAddr_delete = Memberaddr.objects.filter(id_member = id_member).filter(addr = qaddr)
+        # memberAddr_delete.delete()
+        memberAddr.delete()
         content = {
             "message" : "pk :" + pk + " 삭제 완료",
             "result" : {}


### PR DESCRIPTION
## 작업내용
- UPDATE : MemberAddr API 생성
- UPDATE : MemberAddr overlap_dong check 중복 동 체크 로직 생성
- UPDATE : MemberAddr DELETE Json_Pasing 선택한 동 삭제하기. 
```
        # 파라미터 get방식
        # Addr = request.GET['addr']

        # 제이슨 방식
        data = request.body.decode('utf-8')
        received_json_data = json.loads(data)
        Addr = received_json_data['addr']

       #공통 로직
        q = memberAddr.get(addr = Addr)
        q.delete()
```
- UPDATE : MemberAddr PUT NOT_Allow, PUT 매서드 삭제. 
- UPDATE:MemberAddr DoesNotExist Exception filter() > get()으로 수정.

## 배운내용. 
JSON Parsing 에서 serializers를 사용하지 않는다고 하는방법을 배움. 
1. python3 라면 `utf-8`로 바꾼다.
```
data = request.body.decode('utf-8')
```
2. 그 제이슨 파일을 json.loads() 한다.
```
received_json_data = json.loads(data)
```
3. 로드한 제이슨에 필요한 정보를 때서 쓴다. 
```
        id_member = received_json_data['id_member']
        addr = received_json_data['addr']
```

- is_valid() 함수는 serializers를 통해 데이터가 있는경우에만 `TRUE`를 반환한다.
```
                if serializer.is_valid():
                    serializer.save()
```
save()를 하기위해선 is_valid()가 무조건 선행되어야만 한다.