### PR TITLE
[KyungWon] location_search에 paging 적용

### DIFF
--- a/server/daangn/member/urls.py
+++ b/server/daangn/member/urls.py
@@ -10,7 +10,8 @@ urlpatterns = [
     path('member/search', views.member_search, name='member_search'),
     path('member/<id_member>', views.member_detail, name='member_detail'),
     path('member/touch/<id_member>', views.member_touch, name='member_touch'),
-    path('product/search', views.product_search, name='prduct_search'),
+    path('product/search', views.location_search, name='location_search'),
+    # path('product/search', views.product_search, name='prduct_search'),
     path('member/addr/create', views.member_addr_create, name='member_addr_create'),
     path('member/addr/<id_member>', views.member_addr, name='member_addr'),
     path('product/search/category', views.product_category, name='product_category'),
@@ -24,7 +25,6 @@ urlpatterns = [
     path('product/selling/<id_member>', views.selling_product_list, name='selling_product_list'),
     path('review/seller', views.seller_review, name='seller_review_list'),
     path('review/shopper', views.shopper_review, name='shopper_review_list'),
-    path('product/search/location', views.location_search, name='shopper_review_list'),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/server/daangn/member/views.py
+++ b/server/daangn/member/views.py
@@ -500,6 +500,12 @@ def location_search(request):
     '''
     사용자의 위치에 따른 product 검색
     '''
+    # 디폴트 페이지네이션 사용
+    paginator = PageNumberPagination()
+    
+    # 페이지 사이즈를 page_size라는 이름의 파라미터로 받을 거임
+    paginator.page_size_query_param = "page_size"
+
     # GET방식으로 데이터 address, distance 그리고 검색어를 보냄.
     addr = request.GET['addr']
     dis = request.GET['dis']
@@ -529,6 +535,17 @@ def location_search(request):
             "result" : {"입력한 검색어" : Search}
                 }
         return Response(content,status=status.HTTP_204_NO_CONTENT)
+
+    # 페이지 적용된 쿼리셋
+    paginated_product_sum = paginator.paginate_queryset(product_sum, request)
+    # 페이지 파라미터 (page, page_size) 있을 경우
+    # page_size 만 있을 경우 page=1 처럼 동작함
+    # page만 있을 경우 아래 if문 안 탐
+    if paginated_product_sum is not None:
+        serializers = ProductSerializer(paginated_product_sum, many=True)
+        return paginator.get_paginated_response(serializers.data)
+
+    # 페이지 파라미터 없을 경우
     serializer = ProductSerializer(product_sum, many =True)
     return Response(serializer.data)
 


### PR DESCRIPTION
# 작업내용
- urls.py
    - product_search url 삭제
    - location_search url을 /product/search/location -> /product/search 로 변경
- views.py
    - location_search에 페이징 적용

## 예시
`http://localhost:8000/product/search?q=자전거&addr=양재1동&dis=5&page=1&page_size=3`
```json
HTTP 200 OK
Allow: GET, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "count": 1,
    "next": null,
    "previous": null,
    "results": [
        {
            "id_product": 5,
            "id_member": 1,
            "name": "정글북 자전거, 어린이 자전거",
            "price": 20000,
            "info": "어린이 자전거 정글북 모델이예요.\n6세 전후 나이 추천드려요.\n보조바퀴 있구요. \n패달 등 사용감은 있어요.\n승용차로 운반 가능합니다.",
            "category": "자전거",
            "img": "DaangnMarket/server/daangn/api/static/api/img/정글북자전거,어린이자전거의사진120.jpg |||DaangnMarket/server/daangn/api/static/api/img/정글북자전거,어린이자전거의사진221.jpg |||DaangnMarket/server/daangn/api/static/api/img/정글북자전거,어린이자전거의사진322.jpg |||",
            "views": 0,
            "state": "판매중",
            "addr": "양재1동"
        }
    ]
}
```

## 추후 작업 내용
- addr과 dis를 받지 않고 회원의 디폴트 설정 주소 및 주소 반경 거리를 회원 주소 테이블에서 가져오기 (회원 아이디, 혹은 회원테이블 pk를 파라미터로 추가로 받게 해야 함)
- 만약 회원정보를 파라미터로 받지 않을 경우 전국 단위로 물품 검색 기능 제공